### PR TITLE
WIP: snapshot processes should stop when bookie stops 

### DIFF
--- a/include/leveled.hrl
+++ b/include/leveled.hrl
@@ -67,6 +67,9 @@
                         max_inmemory_tablesize :: integer() | undefined,
                         start_snapshot = false :: boolean(),
                         snapshot_query,
+		        %% so a snapshot can monitor the bookie and
+			%% terminate when it does
+                        bookies_pid :: pid(),
                         bookies_mem :: tuple() | undefined,
                         source_penciller :: pid() | undefined,
                         snapshot_longrunning = true :: boolean(),

--- a/src/leveled_bookie.erl
+++ b/src/leveled_bookie.erl
@@ -926,6 +926,7 @@ snapshot_store(LedgerCache, Penciller, Inker, SnapType, Query, LongRunning) ->
                                     source_penciller = Penciller,
                                     snapshot_query = Query,
                                     snapshot_longrunning = LongRunning,
+				    bookies_pid = self(),
                                     bookies_mem = BookiesMem},
     {ok, LedgerSnapshot} = leveled_penciller:pcl_snapstart(PCLopts),
     case SnapType of

--- a/src/leveled_penciller.erl
+++ b/src/leveled_penciller.erl
@@ -593,7 +593,7 @@ init([PCLopts]) ->
             leveled_log:log("P0001", [self()]),
             {ok, State#state{is_snapshot=true,
 			     bookie_monref = BookieMonitor,
-                                source_penciller=SrcPenciller}};
+			     source_penciller=SrcPenciller}};
         {_RootPath, _Snapshot=false, _Q, _BM} ->
             start_from_file(PCLopts)
     end.    
@@ -947,10 +947,9 @@ handle_cast(work_for_clerk, State) ->
 
 
 %% handle the bookie stopping and stop this snapshot
-handle_info({'DOWN', BookieMonRef, process, BookiePid, Info},
-	    State=#state{bookie_monref = BookieMonRef
-			 bookies_pid = BookiePid}) ->
-    
+handle_info({'DOWN', BookieMonRef, process, _BookiePid, _Info},
+	    State=#state{bookie_monref = BookieMonRef}) ->
+    {stop, normal, State};
 handle_info(_Info, State) ->
     {noreply, State}.
 

--- a/src/leveled_penciller.erl
+++ b/src/leveled_penciller.erl
@@ -584,7 +584,12 @@ init([PCLopts]) ->
         {undefined, _Snapshot=true, Query, BookiesMem} ->
             SrcPenciller = PCLopts#penciller_options.source_penciller,
             LongRunning = PCLopts#penciller_options.snapshot_longrunning,
-	    BookieMonitor = erlang:monitor(process, PCLopts#penciller_options.bookies_pid),
+	    BookiesPid = PCLopts#penciller_options.bookies_pid,
+	    BookieMonitor = case BookiesPid of
+				undefined -> undefined;
+				Pid when is_pid(Pid) ->
+				    erlang:monitor(process, Pid)
+			    end,
             {ok, State} = pcl_registersnapshot(SrcPenciller, 
                                                 self(), 
                                                 Query, 


### PR DESCRIPTION
Simplest possible thing, just monitor the bookie and stop when she
does.